### PR TITLE
Migrate from docker-compose to kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,35 @@ This README documents how to provision and test a local multi-node Kubernetes cl
 
 ---
 
+## Running with Kubernetes
+
+### Prerequisites
+
+Before starting, make sure that minikube is running and that the Ingress addon is enabled
+
+```bash
+minikube start
+minikube addons enable ingress
+```
+
+### Applying Kubernetes manifests
+
+From the repository root (`operation/`) run:
+```bash
+kubectl apply -f k8s/
+```
+
+### Accessing the application
+
+Find the minikube IP by running:
+```bash
+minikube ip
+```
+
+Then use that IP in your browser to access the application
+
+---
+
 ## Cluster Overview
 
 * 1 control plane: `ctrl` @ 192.168.56.100

--- a/k8s/ConfigMap.yaml
+++ b/k8s/ConfigMap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+data:
+  APP_SERVICE_URL: http://app-service:5000

--- a/k8s/Ingress.yaml
+++ b/k8s/Ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: app-ingress
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: app
+            port:
+              number: 80

--- a/k8s/app-service.yaml
+++ b/k8s/app-service.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app-service
+  template:
+    metadata:
+      labels:
+        app: app-service
+    spec:
+      containers:
+      - name: app-service
+        image: ghcr.io/remla25-team11/app-service:latest
+        ports:
+        - containerPort: 5000
+        env:
+        - name: MODEL_SERVICE_URL
+          value: http://model-service:8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app-service
+spec:
+  type: NodePort
+  selector:
+    app: app-service
+  ports:
+    - port: 5000
+      targetPort: 5000

--- a/k8s/app.yaml
+++ b/k8s/app.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: app
+        image: ghcr.io/remla25-team11/app:latest
+        ports:
+        - containerPort: 80
+        env:
+        - name: APP_SERVICE_URL
+          value: http://app-service:5000
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app
+spec:
+  selector:
+    app: app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80

--- a/k8s/model-service.yaml
+++ b/k8s/model-service.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: model-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: model-service
+  template:
+    metadata:
+      labels:
+        app: model-service
+    spec:
+      containers:
+      - name: model-service
+        image: ghcr.io/remla25-team11/model-service:latest
+        ports:
+        - containerPort: 8080
+        env:
+        - name: MODEL_URL
+          value: https://github.com/remla25-team11/model-training/releases/download/v0.0.1/c2_Classifier_Sentiment_Model
+        - name: VECTORIZER_URL
+          value: https://github.com/remla25-team11/model-training/releases/download/v0.0.1/c1_BoW_Sentiment_Model.pkl
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: model-service
+spec:
+  selector:
+    app: model-service
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080


### PR DESCRIPTION
Migrated the existing Docker Compose services (app, app-service, model-service) to Kubernetes by creating corresponding Deployments and Services.

- Created a public docker image for app-service [here](https://github.com/orgs/remla25-team11/packages/container/package/app-service), which is automatically deployed when commits in `app/app-service` are pushed ([workflow](https://github.com/remla25-team11/app/blob/main/.github/workflows/docker-build-app-service.yml)).
- Added an Ingress resource to expose the frontend service (app) for external access.
- Configured environment variables and service communication using ConfigMaps and Kubernetes service DNS names.
- Provided instructions for accessing the frontend via Ingress in README