### PR TITLE
Istio sticky session routing between app versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,9 @@ Upload grafana/dashboards/app-dashboard.json.
 
 ## Select Prometheus as the data source and click Import.
 
+
+## Sticky Sessions Istio
+
 #### Prerequisites
 
 Make sure you have:
@@ -249,13 +252,13 @@ kubectl label namespace default istio-injection=enabled
 kubectl port-forward -n istio-system svc/istio-ingressgateway 8080:80
 ```
 
-# Always routes to app v2
+### Always routes to app v2
 
 ```bash
 curl -H "user: test-user" http://localhost:8080/version
 ```
 
-# Always routes to app v1
+### Always routes to app v1
 ```bash
 curl http://localhost:8080/version
 ```

--- a/README.md
+++ b/README.md
@@ -219,5 +219,45 @@ Navigate to Dashboards → Import.
 
 Upload grafana/dashboards/app-dashboard.json.
 
-Select Prometheus as the data source and click Import.
+## Select Prometheus as the data source and click Import.
+
+#### Prerequisites
+
+Make sure you have:
+
+1. Istio installed (if not):
+
+   ```bash
+   istioctl install --set profile=demo -y
+   ```
+2. Sidecar injection enabled:
+
+```bash
+kubectl label namespace default istio-injection=enabled
+```
+3. Apply Gateway, VirtualService, DestinationRule:
+
+   ```bash
+   kubectl apply -f k8s/istio-gateway.yaml
+   kubectl apply -f k8s/virtual-service-app.yaml
+   kubectl apply -f k8s/destination-rule-app.yaml
+   ```
+
+## If you are on macOS or using Minikube, run:
+
+```bash
+kubectl port-forward -n istio-system svc/istio-ingressgateway 8080:80
+```
+
+# Always routes to app v2
+
+```bash
+curl -H "user: test-user" http://localhost:8080/version
+```
+
+# Always routes to app v1
+```bash
+curl http://localhost:8080/version
+```
+
 ---

--- a/k8s/app-v1.yaml
+++ b/k8s/app-v1.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-v1
+  labels:
+    app: app
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: app
+        version: v1
+    spec:
+      containers:
+        - name: app
+          image: ghcr.io/remla25-team11/app:latest
+          ports:
+            - containerPort: 80
+          env:
+            - name: APP_SERVICE_URL
+              value: /api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app
+spec:
+  selector:
+    app: app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+

--- a/k8s/app-v2.yaml
+++ b/k8s/app-v2.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-v2
+  labels:
+    app: app
+    version: v2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+      version: v2
+  template:
+    metadata:
+      labels:
+        app: app
+        version: v2
+    spec:
+      containers:
+        - name: app
+          image: ghcr.io/remla25-team11/app:latest
+          ports:
+            - containerPort: 80
+          env:
+            - name: APP_SERVICE_URL
+              value: /api
+

--- a/k8s/destination-rule-app.yaml
+++ b/k8s/destination-rule-app.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: app-destination
+spec:
+  host: app.default.svc.cluster.local
+  subsets:
+    - name: v1
+      labels:
+        version: v1
+    - name: v2
+      labels:
+        version: v2
+  trafficPolicy:
+    loadBalancer:
+      consistentHash:
+        httpHeaderName: user

--- a/k8s/grafana-dashboard-configmap.yaml
+++ b/k8s/grafana-dashboard-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: app-dashboard
-  namespace: monitoring
+  namespace: default
   labels:
     grafana_dashboard: "1"
 data:

--- a/k8s/istio-gateway.yaml
+++ b/k8s/istio-gateway.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: my-gateway
+spec:
+  selector:
+    istio: ingressgateway 
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - "*"
+

--- a/k8s/virtual-service-app.yaml
+++ b/k8s/virtual-service-app.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: app
+  namespace: default
+spec:
+  hosts:
+    - "*"
+  gateways:
+    - my-gateway
+  http:
+    - match:
+        - headers:
+            user:
+              exact: test-user
+      route:
+        - destination:
+            host: app
+            subset: v2
+    - route:
+        - destination:
+            host: app
+            subset: v1
+


### PR DESCRIPTION
PR adds istio traffic management using sticky session routing between app-v1 and app-v2:

- Requests with user: test-user --> routed to appv2
- All other requests routed to app-v1

Added Istio config (gateway,virtual service, destination rule), separate app version deployments, and readme update