### PR TITLE
Selin alert manager 1/2

### DIFF
--- a/k8s/alertmanager-deployment
+++ b/k8s/alertmanager-deployment
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alertmanager
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alertmanager
+  template:
+    metadata:
+      labels:
+        app: alertmanager
+    spec:
+      containers:
+      - name: alertmanager
+        image: prom/alertmanager:latest
+        args:
+          - "--config.file=/etc/alertmanager/alertmanager.yml"
+        volumeMounts:
+          - name: config
+            mountPath: /etc/alertmanager
+          - name: smtp-secret
+            mountPath: /etc/alertmanager/secrets
+            readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: alertmanager
+        - name: smtp-secret
+          secret:
+            secretName: alertmanager-secret

--- a/k8s/alertmanager.yaml
+++ b/k8s/alertmanager.yaml
@@ -3,18 +3,18 @@ kind: ConfigMap
 metadata:
   name: alertmanager
   namespace: monitoring
-labels:
-  app: alertmanager
+  labels:
+    app: alertmanager
 data:
   alertmanager.yml: |
     global:
       smtp_smarthost: 'smtp.gmail.com:587'
-      smtp_from: 'selinmehmed124@gmail.com'
-      smtp_auth_username: 'selinmehmed124@gmail.com'
-      smtp_auth_password: /etc/alertmanager/secrets/smtp_auth_password
+      smtp_from: 'intheshadowsgirl@gmail.com'
+      smtp_auth_username: 'intheshadowsgirl@gmail.com'
+      smtp_auth_password_file: /etc/alertmanager/secrets/smtp_auth_password
     route:
       receiver: 'team-email'
     receivers:
     - name: 'team-email'
       email_configs:
-      - to: 'intheshadowsgirl@gmail.com'
+      - to: 'selinmehmed124@gmail.com'

--- a/k8s/alertmanager.yaml
+++ b/k8s/alertmanager.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alertmanager
+  namespace: monitoring
+labels:
+  app: alertmanager
+data:
+  alertmanager.yml: |
+    global:
+      smtp_smarthost: 'smtp.gmail.com:587'
+      smtp_from: 'selinmehmed124@gmail.com'
+      smtp_auth_username: 'selinmehmed124@gmail.com'
+      smtp_auth_password: '{{ smtp_password }}'
+    route:
+      receiver: 'team-email'
+    receivers:
+    - name: 'team-email'
+      email_configs:
+      - to: 'intheshadowsgirl@gmail.com'

--- a/k8s/alertmanager.yaml
+++ b/k8s/alertmanager.yaml
@@ -11,7 +11,7 @@ data:
       smtp_smarthost: 'smtp.gmail.com:587'
       smtp_from: 'selinmehmed124@gmail.com'
       smtp_auth_username: 'selinmehmed124@gmail.com'
-      smtp_auth_password: '{{ smtp_password }}'
+      smtp_auth_password: /etc/alertmanager/secrets/smtp_auth_password
     route:
       receiver: 'team-email'
     receivers:

--- a/k8s/app-service-monitor.yaml
+++ b/k8s/app-service-monitor.yaml
@@ -3,7 +3,7 @@ kind: ServiceMonitor
 metadata:
   name: app-service-monitor
   labels:
-    release: prometheus 
+    release: kube-prometheus-stack 
 spec:
   selector:
     matchLabels:

--- a/k8s/prometheus-rule.yaml
+++ b/k8s/prometheus-rule.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: high-traffic-alert
+  namespace: monitoring
+spec:
+  groups:
+  - name: traffic.rules
+    rules:
+    - alert: HighRequestRate
+      expr: rate(http_requests_total[1m]) > 15
+      for: 2m
+      labels:
+        severity: warning
+      annotations:
+        summary: "High request rate !"
+        description: "More than 15 requests per min for 2 min"

--- a/k8s/prometheus-rule.yaml
+++ b/k8s/prometheus-rule.yaml
@@ -3,12 +3,14 @@ kind: PrometheusRule
 metadata:
   name: high-traffic-alert
   namespace: monitoring
+  labels:
+    release: kube-prometheus-stack   
 spec:
   groups:
   - name: traffic.rules
     rules:
     - alert: HighRequestRate
-      expr: rate(http_requests_total[1m]) > 15
+      expr: rate(request_latency_seconds_count[1m]) < 1
       for: 2m
       labels:
         severity: warning

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-secret
+  namespace: monitoring
+type: Opaque
+data:
+  smtp_auth_password: QWRpLUFkaS1BZGktMw==  


### PR DESCRIPTION
An alert that fires when there's no requests, still need to:
- Get it to properly email
- Update the rule to register something meaningful

So far I have a secret to store the password, the rule, and the alert manager + deployment