### PR TITLE
second instance of the model service is deployed - version v3

### DIFF
--- a/k8s/destination-rule-model.yaml
+++ b/k8s/destination-rule-model.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: model-service
+spec:
+  host: model-service
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v3
+    labels:
+      version: v3

--- a/k8s/model-service-v3.yaml
+++ b/k8s/model-service-v3.yaml
@@ -1,18 +1,18 @@
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: model-service
+  name: model-service-v3
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: model-service
-      version: v1
+      version: v3
   template:
     metadata:
       labels:
         app: model-service
+        version: v3
     spec:
       containers:
       - name: model-service
@@ -21,21 +21,8 @@ spec:
         - containerPort: 8000
         env:
         - name: SERVICE_VERSION
-          value: v1   # in model-service.yaml
+          value: v3   
         - name: MODEL_URL
           value: https://github.com/remla25-team11/model-training/releases/download/v0.0.1/c2_Classifier_Sentiment_Model
         - name: VECTORIZER_URL
           value: https://github.com/remla25-team11/model-training/releases/download/v0.0.1/c1_BoW_Sentiment_Model.pkl
-
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: model-service
-spec:
-  selector:
-    app: model-service
-  ports:
-    - protocol: TCP
-      port: 8000
-      targetPort: 8000

--- a/k8s/model-service.yaml
+++ b/k8s/model-service.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: model-service
+        version: v1
     spec:
       containers:
       - name: model-service

--- a/k8s/virtual-service-model.yaml
+++ b/k8s/virtual-service-model.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: model-service
+spec:
+  gateways:
+  - my-gateway  # This must match metadata.name in your istio-gateway.yaml
+  hosts:
+  - "*"
+  http:
+  - match:
+    - uri:
+        prefix: /predict
+    route:
+    - destination:
+        host: model-service
+        subset: v1
+      weight: 100
+    mirror:
+      host: model-service
+      subset: v3


### PR DESCRIPTION
Added virtual-service, destination-rule, and deployment configs to enable Istio-based Shadow Launch for model-service v3. Mirrored traffic is routed to model-service-v3 and monitored via Prometheus metrics.

![image](https://github.com/user-attachments/assets/972eaf9e-6f51-4ef6-bc34-1522b08b6715)


