### PR TITLE
Extra args from Vagrant to Ansible

### DIFF
--- a/ansible/ctrl.yaml
+++ b/ansible/ctrl.yaml
@@ -362,7 +362,7 @@
     # Istio Service Mesh
     - name: Download Istio v{{ istio_version }}
       ansible.builtin.get_url:
-        url: "https://github.com/istio/istio/releases/download/{{ istio_version }}/istio-{{ istio_version }}-linux-arm64.tar.gz"
+        url: "https://github.com/istio/istio/releases/download/{{ istio_version }}/istio-{{ istio_version }}-linux-amd64.tar.gz"
         dest: "/tmp/istio-{{ istio_version }}.tar.gz"
         mode: '0644'
 

--- a/ansible/ctrl.yaml
+++ b/ansible/ctrl.yaml
@@ -362,7 +362,7 @@
     # Istio Service Mesh
     - name: Download Istio v{{ istio_version }}
       ansible.builtin.get_url:
-        url: "https://github.com/istio/istio/releases/download/{{ istio_version }}/istio-{{ istio_version }}-linux-amd64.tar.gz"
+        url: "https://github.com/istio/istio/releases/download/{{ istio_version }}/istio-{{ istio_version }}-linux-arm64.tar.gz"
         dest: "/tmp/istio-{{ istio_version }}.tar.gz"
         mode: '0644'
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -56,10 +56,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       "workers"    => (1..NUM_WORKERS).map { |i| "node-#{i}" }
     }
 
-        # Write the inventory file to the Ansible folder so it is reusable
+        # Write the inventory file to the Ansible folder 
     ansible.inventory_path = "../ansible/inventory.cfg"
 
-    # Expose runtime details (e.g., number of workers) to Ansible as extra vars
+    # Expose runtime details to Ansible as extra vars
     ansible.extra_vars = {
       num_workers:   NUM_WORKERS,
       worker_memory: WORKER_MEMORY,

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -55,5 +55,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       "controller" => ["ctrl"],
       "workers"    => (1..NUM_WORKERS).map { |i| "node-#{i}" }
     }
+
+        # Write the inventory file to the Ansible folder so it is reusable
+    ansible.inventory_path = "../ansible/inventory.cfg"
+
+    # Expose runtime details (e.g., number of workers) to Ansible as extra vars
+    ansible.extra_vars = {
+      num_workers:   NUM_WORKERS,
+      worker_memory: WORKER_MEMORY,
+      worker_cpus:   WORKER_CPUS
+    }
   end
 end


### PR DESCRIPTION
Added:
- Extra arguments are passed from Vagrant to Ansible (e.g., number of workers)
- Vagrant generates a valid inventory.cfg for Ansible that contains all (and only) the active nodes